### PR TITLE
Added constructor without awscredentials. Should use IAM roles instea…

### DIFF
--- a/Rebus.AmazonS3/Config/AmazonS3DataBusConfigurationExtensions.cs
+++ b/Rebus.AmazonS3/Config/AmazonS3DataBusConfigurationExtensions.cs
@@ -72,5 +72,17 @@ namespace Rebus.Config
                 return new AmazonS3DataBusStorage(credentials, config, options, transferUtilityConfig, rebusLoggerFactory, rebusTime);
             });
         }
+
+
+        static void Configure(StandardConfigurer<IDataBusStorage> configurer, AmazonS3Config config, AmazonS3DataBusOptions options, TransferUtilityConfig transferUtilityConfig)
+        {
+            configurer.Register(c =>
+            {
+                var rebusLoggerFactory = c.Get<IRebusLoggerFactory>();
+                var rebusTime = c.Get<IRebusTime>();
+
+                return new AmazonS3DataBusStorage(config, options, transferUtilityConfig, rebusLoggerFactory, rebusTime);
+            });
+        }
     }
 }

--- a/Rebus.AmazonS3/Config/AmazonS3DataBusConfigurationExtensions.cs
+++ b/Rebus.AmazonS3/Config/AmazonS3DataBusConfigurationExtensions.cs
@@ -49,6 +49,19 @@ namespace Rebus.Config
                 transferUtilityConfig ?? new TransferUtilityConfig());
         }
 
+
+        /// <summary>
+        /// Configures the data bus to store data in Amazon S3
+        /// </summary>
+        public static void StoreInAmazonS3(this StandardConfigurer<IDataBusStorage> configurer, AmazonS3Config config, AmazonS3DataBusOptions options, TransferUtilityConfig transferUtilityConfig = null)
+        {
+            if (configurer == null) throw new ArgumentNullException(nameof(configurer));            
+            if (options == null) throw new ArgumentNullException(nameof(options));
+            if (config == null) throw new ArgumentNullException(nameof(config));
+
+            Configure(configurer, config, options, transferUtilityConfig ?? new TransferUtilityConfig());
+        }
+
         static void Configure(StandardConfigurer<IDataBusStorage> configurer, AWSCredentials credentials, AmazonS3Config config, AmazonS3DataBusOptions options, TransferUtilityConfig transferUtilityConfig)
         {
             configurer.Register(c =>


### PR DESCRIPTION
Hej Mogens. 

Vi har lidt udfordringer med databus og s3. Vi bruger IAM roles (i kubernetes) til at styre adgangen til buckets. Se følgende fra aws docs. https://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/net-dg-hosm.html

Det spiller ikke rigtigt med databus, da rebus kun udstiller constructores der tager awscredentials med. 

Dette PR tilføjer en constructor som ikke kræver awscredentials og checker så for de credentials i CreateS3Client metoden.

Jeg kunne ikke bygge projektet på min Mac, så koden er ikke testet.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
