### PR TITLE
#9 fix url

### DIFF
--- a/Rebus.AmazonS3/Rebus.AmazonS3.csproj
+++ b/Rebus.AmazonS3/Rebus.AmazonS3.csproj
@@ -10,7 +10,7 @@
 		<Copyright>Copyright Rebus FM ApS 2012</Copyright>
 		<PackageTags>rebus amazon s3 aws</PackageTags>
 		<PackageDescription>Provides Amazon S3 data bus storage for Rebus</PackageDescription>
-		<RepositoryUrl>https://github.com/rebus-org/Rebus</RepositoryUrl>
+		<RepositoryUrl>https://github.com/rebus-org/Rebus.AmazonS3</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<PackageIcon>little_rebusbus2_copy-500x500.png</PackageIcon>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.

Closes #9 